### PR TITLE
Call id logging samt feilhåndtering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
         }
     }
     implementation("io.ktor:ktor-server-core:$ktor_version")
+    implementation("io.ktor:ktor-server-call-logging:$ktor_version")
     implementation("io.ktor:ktor-server-netty:$ktor_version")
     implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
     implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
     }
     implementation("io.ktor:ktor-server-core:$ktor_version")
     implementation("io.ktor:ktor-server-call-logging:$ktor_version")
+    implementation("io.ktor:ktor-server-call-id:$ktor_version")
+    implementation("io.ktor:ktor-server-status-pages:$ktor_version")
     implementation("io.ktor:ktor-server-netty:$ktor_version")
     implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
     implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")

--- a/src/main/kotlin/no/nav/familie/Application.kt
+++ b/src/main/kotlin/no/nav/familie/Application.kt
@@ -19,6 +19,7 @@ import no.nav.familie.env.DB_PASSWORD
 import no.nav.familie.env.DB_PORT
 import no.nav.familie.env.DB_USERNAME
 import no.nav.familie.env.SANITY_PROJECT_ID
+import no.nav.familie.plugins.configureLogging
 import no.nav.familie.plugins.configureRouting
 import org.flywaydb.core.Flyway
 import org.slf4j.LoggerFactory
@@ -74,6 +75,7 @@ fun main() {
             module {
                 main()
                 configureRouting(client)
+                configureLogging()
             }
             connector {
                 port = 8080

--- a/src/main/kotlin/no/nav/familie/Application.kt
+++ b/src/main/kotlin/no/nav/familie/Application.kt
@@ -21,6 +21,7 @@ import no.nav.familie.env.DB_USERNAME
 import no.nav.familie.env.SANITY_PROJECT_ID
 import no.nav.familie.plugins.configureLogging
 import no.nav.familie.plugins.configureRouting
+import no.nav.familie.plugins.errorHandling
 import org.flywaydb.core.Flyway
 import org.slf4j.LoggerFactory
 
@@ -73,9 +74,10 @@ fun main() {
         Netty,
         environment = applicationEngineEnvironment {
             module {
+                configureLogging()
+                errorHandling()
                 main()
                 configureRouting(client)
-                configureLogging()
             }
             connector {
                 port = 8080

--- a/src/main/kotlin/no/nav/familie/plugins/ErrorHandling.kt
+++ b/src/main/kotlin/no/nav/familie/plugins/ErrorHandling.kt
@@ -9,6 +9,7 @@ import io.ktor.server.application.log
 import io.ktor.server.plugins.callid.callId
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.request.header
+import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 import io.ktor.server.response.respond
 import org.slf4j.MDC
@@ -26,7 +27,10 @@ fun Application.errorHandling() {
                     else -> HttpStatusCode.InternalServerError
                 }
 
-                call.application.log.error("Feilet håndtering av ${call.request.path()} status=$responseStatus", cause)
+                call.application.log.error(
+                    "Feilet håndtering av ${call.request.httpMethod} - ${call.request.path()} status=$responseStatus",
+                    cause
+                )
                 call.respond(
                     responseStatus,
                     mapOf(

--- a/src/main/kotlin/no/nav/familie/plugins/ErrorHandling.kt
+++ b/src/main/kotlin/no/nav/familie/plugins/ErrorHandling.kt
@@ -1,0 +1,54 @@
+package no.nav.familie.plugins
+
+import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.install
+import io.ktor.server.application.log
+import io.ktor.server.plugins.callid.callId
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.request.header
+import io.ktor.server.request.path
+import io.ktor.server.response.respond
+import org.slf4j.MDC
+
+fun Application.errorHandling() {
+    install(StatusPages) {
+        exception<Throwable> { call, cause ->
+            try {
+                setMdcValues(call)
+
+                val responseStatus: HttpStatusCode = when (cause) {
+                    is ResponseException -> cause.response.status
+                    // Catcher SerializationException/JsonDecodingException
+                    is IllegalArgumentException -> HttpStatusCode.BadRequest
+                    else -> HttpStatusCode.InternalServerError
+                }
+
+                call.application.log.error("Feilet håndtering av ${call.request.path()} status=$responseStatus", cause)
+                call.respond(
+                    responseStatus,
+                    mapOf(
+                        "status" to "FEILET",
+                        "errorMelding" to cause.message
+                    )
+                )
+            } finally {
+                removeMdcValues()
+            }
+        }
+    }
+}
+
+private fun removeMdcValues() {
+    MDC.remove(MDCConstants.CALL_ID)
+    MDC.remove(MDCConstants.CONSUMER_ID)
+    MDC.remove(MDCConstants.USER_ID)
+}
+
+private fun setMdcValues(call: ApplicationCall) {
+    MDC.put(MDCConstants.CALL_ID, call.callId)
+    MDC.put(MDCConstants.CONSUMER_ID, call.request.header("Nav-Consumer-Id"))
+    MDC.put(MDCConstants.USER_ID, call.request.cookies[RANDOM_USER_ID_COOKIE_NAME])
+}

--- a/src/main/kotlin/no/nav/familie/plugins/Logging.kt
+++ b/src/main/kotlin/no/nav/familie/plugins/Logging.kt
@@ -2,12 +2,13 @@ package no.nav.familie.plugins
 
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import io.ktor.server.plugins.callid.CallId
 import io.ktor.server.plugins.callloging.CallLogging
 import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.request.header
 import java.util.UUID
 
-private const val RANDOM_USER_ID_COOKIE_NAME = "RUIDC"
+const val RANDOM_USER_ID_COOKIE_NAME = "RUIDC"
 
 object MDCConstants {
     const val CONSUMER_ID = "consumerId"
@@ -16,6 +17,10 @@ object MDCConstants {
 }
 
 fun Application.configureLogging() {
+    install(CallId) {
+        retrieve { resolveCallId(it.request) }
+        replyToHeader("Nav-Call-Id")
+    }
     install(CallLogging) {
         disableDefaultColors()
         mdc(MDCConstants.CONSUMER_ID) { call ->

--- a/src/main/kotlin/no/nav/familie/plugins/Logging.kt
+++ b/src/main/kotlin/no/nav/familie/plugins/Logging.kt
@@ -1,0 +1,47 @@
+package no.nav.familie.plugins
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.callloging.CallLogging
+import io.ktor.server.request.ApplicationRequest
+import io.ktor.server.request.header
+import java.util.UUID
+
+private const val RANDOM_USER_ID_COOKIE_NAME = "RUIDC"
+
+object MDCConstants {
+    const val CONSUMER_ID = "consumerId"
+    const val USER_ID = "userId"
+    const val CALL_ID = "callId"
+}
+
+fun Application.configureLogging() {
+    install(CallLogging) {
+        disableDefaultColors()
+        mdc(MDCConstants.CONSUMER_ID) { call ->
+            call.request.header("Nav-Consumer-Id")
+        }
+        mdc(MDCConstants.USER_ID) {
+            it.request.cookies[RANDOM_USER_ID_COOKIE_NAME]
+        }
+        mdc(MDCConstants.CALL_ID) { call ->
+            resolveCallId(call.request)
+        }
+    }
+}
+
+private val NAV_CALL_ID_HEADER_NAMES =
+    setOf(
+        "Nav-Call-Id",
+        "Nav-CallId",
+        "Nav-Callid",
+        "X-Correlation-Id"
+    )
+
+private fun resolveCallId(request: ApplicationRequest): String {
+    return NAV_CALL_ID_HEADER_NAMES
+        .asSequence()
+        .mapNotNull { request.header(it) }
+        .firstOrNull { it.isNotEmpty() }
+        ?: UUID.randomUUID().toString()
+}

--- a/src/main/kotlin/no/nav/familie/plugins/Routing.kt
+++ b/src/main/kotlin/no/nav/familie/plugins/Routing.kt
@@ -40,7 +40,6 @@ val logger: Logger = LoggerFactory.getLogger("no.nav.familie.routing")
 fun Application.configureRouting(client: SanityClient) {
     routing {
         post("/endringslogg") {
-            logger.info("Henter ut endringslogg")
             val (userId, appId, dataset, maxEntries) = call.receive<BrukerData>()
             val seenEntryIds = getSeenEntriesForUser(userId).map(UUID::toString).toSet()
             val seenForcedEntryIds = getSeenForcedEntriesForUser(userId).map(UUID::toString).toSet()


### PR DESCRIPTION
Lagt til logging av CallId/RequestId/UserId
Returnerer callId i response

Pga at MDC-verdier fra CallLogging så må de settes separat når man håndterer exception
Alle feil blir håndtert som error i feilhåndteringen, muligens vi endre noe av det senere