### PR TITLE
Utvid read-timeout mot sanity til nesten en time. Den bør utgå før ca…

### DIFF
--- a/src/main/kotlin/no/nav/familie/SanityClient.kt
+++ b/src/main/kotlin/no/nav/familie/SanityClient.kt
@@ -146,7 +146,7 @@ class SanityClient(
 
     private fun subscribeToSanityApp(listenUrl: String, queryString: String, dataset: String) {
         val eventHandler = MessageEventHandler()
-        val eventSource: BackgroundEventSource = BackgroundEventSource.Builder(eventHandler, EventSource.Builder(HttpConnectStrategy.http(URI.create(listenUrl)).readTimeout(30, TimeUnit.MINUTES)))
+        val eventSource: BackgroundEventSource = BackgroundEventSource.Builder(eventHandler, EventSource.Builder(HttpConnectStrategy.http(URI.create(listenUrl)).readTimeout(57, TimeUnit.MINUTES)))
             .connectionErrorHandler(SanityConnectionErrorHandler())
             .build()
 


### PR DESCRIPTION
…chen flushes for at man skal subscribe på nytt etter en time.

(Forventet) Flyt:
1. Kall mot endepunkt
2. Hent fra sanity - subscribe på endringer (57 minutter) og legg svaret i cache (60 minutter)
3. Endringer i sanity innen 57 minutter fanges opp og oppdaterer cachen
4. Endringer i sanity etter 60 minutter bør trigge ny subscribe

