### PR TITLE
Skru på logg-splitting til Elastic og Loki

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -19,6 +19,11 @@ spec:
         databases:
           - envVarPrefix: db
             name: familie-endringslogg
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   ingresses:
     - https://familie-endringslogg.intern.dev.nav.no
   replicas:

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -19,6 +19,11 @@ spec:
         databases:
           - envVarPrefix: db
             name: familie-endringslogg
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   ingresses:
     - https://familie-endringslogg.intern.nav.no
   replicas:


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Skrur på logg-splitting for app, som betyr at vi sender logs til både Elastic (Kibana) og (Grafana) Loki. Dette er en midlertidig løsning mens vi enda blir kjent med Loki og får satt opp ting slik vi ønsker det.

Favro: NAV-25157